### PR TITLE
Remove use of prototype extensions.

### DIFF
--- a/app/components/loading-balls.js
+++ b/app/components/loading-balls.js
@@ -1,14 +1,4 @@
-import Ember from 'ember';
+import LoadingComponent from './loading-component';
 
-export default Ember.Component.extend({
-  size: 250,
-  color: 'white',
-
-  loadingSvgSize: function() {
-    return this.get('size')
-  }.property('size'),
-
-  loadingSvgColor: function() {
-    return this.get('color');
-  }.property('color')
+export default LoadingComponent.extend({
 });

--- a/app/components/loading-bars.js
+++ b/app/components/loading-bars.js
@@ -1,14 +1,4 @@
-import Ember from 'ember';
+import LoadingComponent from './loading-component';
 
-export default Ember.Component.extend({
-  size: 250,
-  color: 'white',
-
-  loadingSvgSize: function() {
-    return this.get('size')
-  }.property('size'),
-
-  loadingSvgColor: function() {
-    return this.get('color');
-  }.property('color')
+export default LoadingComponent.extend({
 });

--- a/app/components/loading-bubbles.js
+++ b/app/components/loading-bubbles.js
@@ -1,14 +1,4 @@
-import Ember from 'ember';
+import LoadingComponent from './loading-component';
 
-export default Ember.Component.extend({
-  size: 250,
-  color: 'white',
-
-  loadingSvgSize: function() {
-    return this.get('size')
-  }.property('size'),
-
-  loadingSvgColor: function() {
-    return this.get('color');
-  }.property('color')
+export default LoadingComponent.extend({
 });

--- a/app/components/loading-component.js
+++ b/app/components/loading-component.js
@@ -1,0 +1,10 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+	size: 250,
+	color: 'white',
+
+	loadingSvgSize: Ember.computed.alias('size'),
+
+	loadingSvgColor: Ember.computed.alias('color')
+});

--- a/app/components/loading-cubes.js
+++ b/app/components/loading-cubes.js
@@ -1,14 +1,4 @@
-import Ember from 'ember';
+import LoadingComponent from './loading-component';
 
-export default Ember.Component.extend({
-  size: 250,
-  color: 'white',
-
-  loadingSvgSize: function() {
-    return this.get('size')
-  }.property('size'),
-
-  loadingSvgColor: function() {
-    return this.get('color');
-  }.property('color')
+export default LoadingComponent.extend({
 });

--- a/app/components/loading-cylon.js
+++ b/app/components/loading-cylon.js
@@ -1,14 +1,4 @@
-import Ember from 'ember';
+import LoadingComponent from './loading-component';
 
-export default Ember.Component.extend({
-  size: 250,
-  color: 'white',
-
-  loadingSvgSize: function() {
-    return this.get('size')
-  }.property('size'),
-
-  loadingSvgColor: function() {
-    return this.get('color');
-  }.property('color')
+export default LoadingComponent.extend({
 });

--- a/app/components/loading-spin.js
+++ b/app/components/loading-spin.js
@@ -1,14 +1,4 @@
-import Ember from 'ember';
+import LoadingComponent from './loading-component';
 
-export default Ember.Component.extend({
-  size: 250,
-  color: 'white',
-
-  loadingSvgSize: function() {
-    return this.get('size')
-  }.property('size'),
-
-  loadingSvgColor: function() {
-    return this.get('color');
-  }.property('color')
+export default LoadingComponent.extend({
 });

--- a/app/components/loading-spinning-bubbles.js
+++ b/app/components/loading-spinning-bubbles.js
@@ -1,14 +1,4 @@
-import Ember from 'ember';
+import LoadingComponent from './loading-component';
 
-export default Ember.Component.extend({
-  size: 250,
-  color: 'white',
-
-  loadingSvgSize: function() {
-    return this.get('size')
-  }.property('size'),
-
-  loadingSvgColor: function() {
-    return this.get('color');
-  }.property('color')
+export default LoadingComponent.extend({
 });

--- a/app/components/loading-spokes.js
+++ b/app/components/loading-spokes.js
@@ -1,14 +1,4 @@
-import Ember from 'ember';
+import LoadingComponent from './loading-component';
 
-export default Ember.Component.extend({
-  size: 250,
-  color: 'white',
-
-  loadingSvgSize: function() {
-    return this.get('size')
-  }.property('size'),
-
-  loadingSvgColor: function() {
-    return this.get('color');
-  }.property('color')
+export default LoadingComponent.extend({
 });


### PR DESCRIPTION
Not all applications use the prototype extensions, thus making these
components unusable.
