### PR TITLE
Replace bind-attr with new syntax for ember >= 0.11

### DIFF
--- a/app/templates/components/loading-balls.hbs
+++ b/app/templates/components/loading-balls.hbs
@@ -1,4 +1,4 @@
-<svg class="icon-loading" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" {{bind-attr width=loadingSvgSize height=loadingSvgSize fill=loadingSvgColor}}>
+<svg class="icon-loading" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width={{loadingSvgSize}} height={{loadingSvgSize}} fill={{loadingSvgColor}}>
   <path transform="translate(-8 0)" d="M4 12 A4 4 0 0 0 4 20 A4 4 0 0 0 4 12"> 
     <animateTransform attributeName="transform" type="translate" values="-8 0; 2 0; 2 0;" dur="0.8s" repeatCount="indefinite" begin="0" keytimes="0;.25;1" keySplines="0.2 0.2 0.4 0.8;0.2 0.6 0.4 0.8" calcMode="spline"  />
   </path>

--- a/app/templates/components/loading-bars.hbs
+++ b/app/templates/components/loading-bars.hbs
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" {{bind-attr width=loadingSvgSize height=loadingSvgSize fill=loadingSvgColor}}>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width={{loadingSvgSize}} height={{loadingSvgSize}} fill={{loadingSvgColor}}>
   <path transform="translate(2)" d="M0 12 V20 H4 V12z"> 
     <animate attributeName="d" values="M0 12 V20 H4 V12z; M0 4 V28 H4 V4z; M0 12 V20 H4 V12z; M0 12 V20 H4 V12z" dur="1.2s" repeatCount="indefinite" begin="0" keytimes="0;.2;.5;1" keySplines="0.2 0.2 0.4 0.8;0.2 0.6 0.4 0.8;0.2 0.8 0.4 0.8" calcMode="spline"  />
   </path>

--- a/app/templates/components/loading-bubbles.hbs
+++ b/app/templates/components/loading-bubbles.hbs
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" {{bind-attr width=loadingSvgSize height=loadingSvgSize fill=loadingSvgColor}}>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width={{loadingSvgSize}} height={{loadingSvgSize}} fill={{loadingSvgColor}}>
   <circle transform="translate(8 0)" cx="0" cy="16" r="0"> 
     <animate attributeName="r" values="0; 4; 0; 0" dur="1.2s" repeatCount="indefinite" begin="0"
       keytimes="0;0.2;0.7;1" keySplines="0.2 0.2 0.4 0.8;0.2 0.6 0.4 0.8;0.2 0.6 0.4 0.8" calcMode="spline" />

--- a/app/templates/components/loading-cubes.hbs
+++ b/app/templates/components/loading-cubes.hbs
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" {{bind-attr width=loadingSvgSize height=loadingSvgSize fill=loadingSvgColor}}>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width={{loadingSvgSize}} height={{loadingSvgSize}} fill={{loadingSvgColor}}>
   <path transform="translate(-8 0)" d="M0 12 V20 H8 V12z"> 
     <animateTransform attributeName="transform" type="translate" values="-8 0; 2 0; 2 0;" dur="0.8s" repeatCount="indefinite" begin="0" keytimes="0;.25;1" keySplines="0.2 0.2 0.4 0.8;0.2 0.6 0.4 0.8" calcMode="spline"  />
   </path>

--- a/app/templates/components/loading-cylon.hbs
+++ b/app/templates/components/loading-cylon.hbs
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" {{bind-attr width=loadingSvgSize height=loadingSvgSize fill=loadingSvgColor}}>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width={{loadingSvgSize}} height={{loadingSvgSize}} fill={{loadingSvgColor}}>
   <path transform="translate(0 0)" d="M0 12 V20 H4 V12z">
     <animateTransform attributeName="transform" type="translate" values="0 0; 28 0; 0 0; 0 0" dur="1.5s" begin="0" repeatCount="indefinite" keytimes="0;0.3;0.6;1" keySplines="0.2 0.2 0.4 0.8;0.2 0.2 0.4 0.8;0.2 0.2 0.4 0.8" calcMode="spline" />
   </path>

--- a/app/templates/components/loading-spin.hbs
+++ b/app/templates/components/loading-spin.hbs
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" {{bind-attr width=loadingSvgSize height=loadingSvgSize fill=loadingSvgColor}}>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width={{loadingSvgSize}} height={{loadingSvgSize}} fill={{loadingSvgColor}}>
   <path opacity=".25" d="M16 0 A16 16 0 0 0 16 32 A16 16 0 0 0 16 0 M16 4 A12 12 0 0 1 16 28 A12 12 0 0 1 16 4"/>
   <path d="M16 0 A16 16 0 0 1 32 16 L28 16 A12 12 0 0 0 16 4z">
     <animateTransform attributeName="transform" type="rotate" from="0 16 16" to="360 16 16" dur="0.8s" repeatCount="indefinite" />

--- a/app/templates/components/loading-spinning-bubbles.hbs
+++ b/app/templates/components/loading-spinning-bubbles.hbs
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" {{bind-attr width=loadingSvgSize height=loadingSvgSize fill=loadingSvgColor}}>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width={{loadingSvgSize}} height={{loadingSvgSize}} fill={{loadingSvgColor}}>
   <circle cx="16" cy="3" r="0">
     <animate attributeName="r" values="0;3;0;0" dur="1s" repeatCount="indefinite" begin="0" keySplines="0.2 0.2 0.4 0.8;0.2 0.2 0.4 0.8;0.2 0.2 0.4 0.8" calcMode="spline" />
   </circle>

--- a/app/templates/components/loading-spokes.hbs
+++ b/app/templates/components/loading-spokes.hbs
@@ -1,4 +1,4 @@
-<svg id="loading" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" {{bind-attr width=loadingSvgSize height=loadingSvgSize fill=loadingSvgColor}}>
+<svg id="loading" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width={{loadingSvgSize}} height={{loadingSvgSize}} fill={{loadingSvgColor}}>
   <path opacity=".1" d="M14 0 H18 V8 H14 z" transform="rotate(0 16 16)">
     <animate attributeName="opacity" from="1" to=".1" dur="1s" repeatCount="indefinite" begin="0"/>
   </path>


### PR DESCRIPTION
`bind-attr` is deprecated and will be removed from emberjs 2.0
